### PR TITLE
Add progressbar to File Uploads

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -52,6 +52,7 @@ function saveFile() {
   if(file.size <=  MAX_SIZE) {
     const form = new FormData();
     form.append('page[file]', file);
+    const progressBar = $('#file-upload-progress');
 
     $.ajax({
       async: true,
@@ -61,12 +62,15 @@ function saveFile() {
       cache: false,
       contentType: false,
       data: form,
+      beforeSend: function () {
+        progressBar.addClass('active');
+      },
       xhr: function () {
         var newXhr = $.ajaxSettings.xhr();
         if(newXhr.upload) {
           newXhr.upload.addEventListener('progress', function (e) {
             if (e.lengthComputable) {
-              $('#file-upload-progress').attr({
+              progressBar.attr({
                 value: e.loaded,
                 max: e.total
               });
@@ -80,6 +84,9 @@ function saveFile() {
       },
       error: function (e) {
         displayErrorMessage();
+      },
+      complete: function () {
+        progressBar.removeClass('active');
       }
     });
   } else {

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,7 +20,7 @@
 function getPagePath() {
   const container = $("#container");
   const pagePath = "/" + container.attr("data-path");
-  
+
   return pagePath;
 }
 
@@ -52,21 +52,36 @@ function saveFile() {
   if(file.size <=  MAX_SIZE) {
     const form = new FormData();
     form.append('page[file]', file);
-  
+
     $.ajax({
       async: true,
       url: getPagePath(),
       type: 'PATCH',
-      processData: false, 
+      processData: false,
+      cache: false,
       contentType: false,
       data: form,
+      xhr: function () {
+        var newXhr = $.ajaxSettings.xhr();
+        if(newXhr.upload) {
+          newXhr.upload.addEventListener('progress', function (e) {
+            if (e.lengthComputable) {
+              $('#file-upload-progress').attr({
+                value: e.loaded,
+                max: e.total
+              });
+            }
+          }, false);
+        }
+        return newXhr;
+      },
       success: function (resp) {
         location.reload();
       },
       error: function (e) {
         displayErrorMessage();
       }
-    }); 
+    });
   } else {
     displayErrorMessage();
   }

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -68,3 +68,11 @@ div {
 label {
   display: block;
 }
+
+progress {
+  display: none;
+
+  &.active {
+    display: block;
+  }
+}

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -32,5 +32,5 @@
       <% end %>
     </div>
   </div>
-  <progress id="file-upload-progress"></progress>
+  <progress id="file-upload-progress" value="0"></progress>
 </div>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,6 +1,6 @@
 <% title @page.url %>
 
-<h1>Dontfile</h1> 
+<h1>Dontfile</h1>
 
 <div id="container" data-path="<%= @page.url %>">
   <div id="text-area">
@@ -24,7 +24,7 @@
           <a class="button" title='Download File' href="<%= rails_blob_url(@page.file) %>" download>
             <%= icon('far', 'arrow-alt-circle-down') %>
           </a>
-          
+
           <%= button_to delete_file_path, method: :delete, params: { url: @page.url }, title: 'Delete File', data: { confirm: "Are you sure?" } do %>
             <%= icon('far', 'trash-alt') %>
           <% end %>
@@ -32,4 +32,5 @@
       <% end %>
     </div>
   </div>
+  <progress id="file-upload-progress"></progress>
 </div>


### PR DESCRIPTION
Closes https://github.com/MatheusRich/dontfile/issues/21

## Description
- Added `progressbar` component to the show page with initial value of `0`.
- Added `beforeLoad` and `complete` callbacks inside the `ajax` call for showing and hiding the progressbar on each new file upload.

## How it looks.

![After](http://g.recordit.co/N8WczgPfiy.gif)