### PR TITLE
Feature/change icons depending of uploaded file

### DIFF
--- a/app/assets/stylesheets/pages.scss
+++ b/app/assets/stylesheets/pages.scss
@@ -35,7 +35,7 @@
 }
 
 #attachment {
-  display: flex;  
+  display: flex;
   flex-direction: row;
   align-items: center;
   @media screen and (max-width: "768px") {
@@ -50,16 +50,16 @@
 
   i {
     font-size: 25px;
-    height: auto; 
-    width: auto; 
+    height: auto;
+    width: auto;
   }
   i[class^='far fa-file-'] {
     font-size: 4em;
   }
   img {
-    height: auto; 
-    width: auto; 
-    max-width: 50px; 
+    height: auto;
+    width: auto;
+    max-width: 50px;
     max-height: 50px
   }
 }
@@ -71,7 +71,7 @@
   }
 
   &-title {
-    font-size: 5.5em;            
+    font-size: 5.5em;
   }
 
   &-description {

--- a/app/assets/stylesheets/pages.scss
+++ b/app/assets/stylesheets/pages.scss
@@ -53,7 +53,7 @@
     height: auto; 
     width: auto; 
   }
-  .fa-file-alt {
+  i[class^='far fa-file-'] {
     font-size: 4em;
   }
   img {

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,12 +1,12 @@
 module PagesHelper
   def attachment_icon(content_type)
     icon_classes = case content_type
-                   when /\/pdf/ then { style: "fa", name: "file-pdf" }
-                   when /image\// then { style: "fa", name: "file-image" }
-                   when /\/zip/ then { style: "fa", name: "file-archive" }
+                   when /\/pdf/ then { style: "far", name: "file-pdf" }
+                   when /image\// then { style: "far", name: "file-image" }
+                   when /\/zip/ then { style: "far", name: "file-archive" }
                    when /video\// then { style: "far", name: "file-video" }
                    else
-                     { style: "fa", name: "file-alt" }
+                     { style: "far", name: "file-alt" }
     end
 
     icon(icon_classes[:style], icon_classes[:name])

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,2 +1,14 @@
 module PagesHelper
+  def attachment_icon(content_type)
+    icon_classes = case content_type
+    when /\/pdf/ then { style: "fa", name: "file-pdf" }
+    when /image\// then { style: "fa", name: "file-image" }
+    when /\/zip/ then { style: "fa", name: "file-archive" }
+    when /video\// then { style: "far", name: "file-video" }
+    else
+      { style: "fa", name: "file-alt" }
+   end
+
+    icon(icon_classes[:style], icon_classes[:name])
+  end
 end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,13 +1,13 @@
 module PagesHelper
   def attachment_icon(content_type)
     icon_classes = case content_type
-    when /\/pdf/ then { style: "fa", name: "file-pdf" }
-    when /image\// then { style: "fa", name: "file-image" }
-    when /\/zip/ then { style: "fa", name: "file-archive" }
-    when /video\// then { style: "far", name: "file-video" }
-    else
-      { style: "fa", name: "file-alt" }
-   end
+                   when /\/pdf/ then { style: "fa", name: "file-pdf" }
+                   when /image\// then { style: "fa", name: "file-image" }
+                   when /\/zip/ then { style: "fa", name: "file-archive" }
+                   when /video\// then { style: "far", name: "file-video" }
+                   else
+                     { style: "fa", name: "file-alt" }
+    end
 
     icon(icon_classes[:style], icon_classes[:name])
   end

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -17,7 +17,7 @@
 
     <div id="attachment">
       <% if @page.file.attached? %>
-        <%= icon('far', 'file-alt') %>
+        <%= attachment_icon(@page.file_blob.content_type) %>
         <p><%= @page.file_blob.filename %></p>
 
         <div id="buttons">

--- a/test/helpers/pages_helper_test.rb
+++ b/test/helpers/pages_helper_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+include FontAwesome::Sass::Rails::ViewHelpers
+
+class PagesHelperTest < ActionView::TestCase
+  test "should get the icon of video when a video uploaded" do
+    assert_dom_equal(%{<i class="far fa-file-video"></i>}, attachment_icon("video/mp4"))
+  end
+
+  test "should get the icon of image when an image uploaded" do
+    assert_dom_equal(%{<i class="fa fa-file-image"></i>}, attachment_icon("image/jpeg"))
+  end
+
+  test "should get the icon of zip when zip file uploaded" do
+    assert_dom_equal(%{<i class="fa fa-file-image"></i>}, attachment_icon("image/jpeg"))
+  end
+
+  test "should get the icon of pdf when pdf file uploaded" do
+    assert_dom_equal(%{<i class="fa fa-file-pdf"></i>}, attachment_icon("application/pdf"))
+  end
+
+  test "should get the default icon when another extension file uploaded" do
+    assert_dom_equal(%{<i class="fa fa-file-alt"></i>}, attachment_icon("application/csv"))
+  end
+end

--- a/test/helpers/pages_helper_test.rb
+++ b/test/helpers/pages_helper_test.rb
@@ -7,18 +7,18 @@ class PagesHelperTest < ActionView::TestCase
   end
 
   test "should get the icon of image when an image uploaded" do
-    assert_dom_equal(%{<i class="fa fa-file-image"></i>}, attachment_icon("image/jpeg"))
+    assert_dom_equal(%{<i class="far fa-file-image"></i>}, attachment_icon("image/jpeg"))
   end
 
   test "should get the icon of zip when zip file uploaded" do
-    assert_dom_equal(%{<i class="fa fa-file-archive"></i>}, attachment_icon("application/zip"))
+    assert_dom_equal(%{<i class="far fa-file-archive"></i>}, attachment_icon("application/zip"))
   end
 
   test "should get the icon of pdf when pdf file uploaded" do
-    assert_dom_equal(%{<i class="fa fa-file-pdf"></i>}, attachment_icon("application/pdf"))
+    assert_dom_equal(%{<i class="far fa-file-pdf"></i>}, attachment_icon("application/pdf"))
   end
 
   test "should get the default icon when another extension file uploaded" do
-    assert_dom_equal(%{<i class="fa fa-file-alt"></i>}, attachment_icon("application/csv"))
+    assert_dom_equal(%{<i class="far fa-file-alt"></i>}, attachment_icon("application/csv"))
   end
 end

--- a/test/helpers/pages_helper_test.rb
+++ b/test/helpers/pages_helper_test.rb
@@ -11,7 +11,7 @@ class PagesHelperTest < ActionView::TestCase
   end
 
   test "should get the icon of zip when zip file uploaded" do
-    assert_dom_equal(%{<i class="fa fa-file-image"></i>}, attachment_icon("image/jpeg"))
+    assert_dom_equal(%{<i class="fa fa-file-archive"></i>}, attachment_icon("application/zip"))
   end
 
   test "should get the icon of pdf when pdf file uploaded" do


### PR DESCRIPTION
It closes #60
Change the file icon depending of the uploaded file

- Create the attachment_icon method in the pages helper to manage the correct icon rendering
Before:
<img width="552" alt="screen shot 2018-10-09 at 12 25 03 pm" src="https://user-images.githubusercontent.com/11136732/46686716-a0fd9c00-cbbe-11e8-8537-ea8f85fa888a.png">

After:
<img width="543" alt="screen shot 2018-10-09 at 3 27 05 pm" src="https://user-images.githubusercontent.com/11136732/46696581-20e43000-cbd8-11e8-96a1-bf340aca0061.png">
<img width="640" alt="screen shot 2018-10-09 at 3 27 26 pm" src="https://user-images.githubusercontent.com/11136732/46696582-20e43000-cbd8-11e8-9c15-eac405c9b340.png">
<img width="607" alt="screen shot 2018-10-09 at 3 27 41 pm" src="https://user-images.githubusercontent.com/11136732/46696583-217cc680-cbd8-11e8-85ae-6000286887c4.png">
<img width="629" alt="screen shot 2018-10-09 at 3 27 54 pm" src="https://user-images.githubusercontent.com/11136732/46696584-217cc680-cbd8-11e8-9f95-cae78d6cd41a.png">
<img width="485" alt="screen shot 2018-10-09 at 3 28 39 pm" src="https://user-images.githubusercontent.com/11136732/46696585-217cc680-cbd8-11e8-91da-d9852f764e81.png">
