### PR TITLE
chore: align ruby version in Dockerfile to project version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.5.1
 
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
 


### PR DESCRIPTION
### What does this implement/fix? ###

Update the Docker image to use version 2.5.1

### Does this close any currently open issues? ###

#58

### Explain your workflow ###

What steps/decisions did you take to reach the current state of PR.
I forked, and made a new feature branch. 
Changed version
Tested
Made one commit

### Any other comments? ###

Test output

# rails test
Run options: --seed 41948

# Running:

...............

Finished in 4.616682s, 3.2491 runs/s, 7.3646 assertions/s.
15 runs, 34 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /dontfile/coverage. 45 / 45 LOC (100.0%) covered.
# rails --version
Rails 5.2.1
# ruby --version
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux]


