### PR TITLE
Add poppler to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_install:
     > cc-test-reporter
   - chmod +x cc-test-reporter
   - "./cc-test-reporter before-build"
+  - sudo apt-get install -qq qpdf ghostscript poppler-utils
+  - echo `which pdfinfo`
 before_script:
   - cp config/database.yml.travis config/database.yml
   - psql -c 'create database dontfile_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,26 +4,26 @@ env:
 language: ruby
 sudo: required
 rvm:
-- 2.5.1
+  - 2.5.1
 addons:
   postgresql: 9.6
 cache: bundler
 before_install:
-- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
-  > cc-test-reporter
-- chmod +x cc-test-reporter
-- "./cc-test-reporter before-build"
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+    > cc-test-reporter
+  - chmod +x cc-test-reporter
+  - "./cc-test-reporter before-build"
 before_script:
-- cp config/database.yml.travis config/database.yml
-- psql -c 'create database dontfile_test;' -U postgres
+  - cp config/database.yml.travis config/database.yml
+  - psql -c 'create database dontfile_test;' -U postgres
 script:
-- bundle install
-- bundle exec rails db:create
-- bundle exec rails db:migrate RAILS_ENV=test
-- bundle exec rails test
-- bundle exec rubocop
+  - bundle install
+  - bundle exec rails db:create
+  - bundle exec rails db:migrate RAILS_ENV=test
+  - bundle exec rails test
+  - bundle exec rubocop
 after_script:
-- "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
+  - "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
 deploy:
   on:
     tags: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ruby:2.5.1
 
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN apt-get update -qq &&\
+    apt-get install -y build-essential libpq-dev nodejs poppler-utils ffmpeg
 
 WORKDIR /dontfile
 


### PR DESCRIPTION
### What does this implement/fix? ###

Adds poppler to travis ci in order to be able to render PDFs in tests

### Does this close any currently open issues? ###

No

### Explain your workflow ###

Edit the `.travis.yml` file to include the installation of poppler utils before running the suite

### Any other comments? ###

This is needed for upcoming implementations such as #66 
This is being shipped separately to prevent false positives and easier revert if needed

ActiveStorage has the capability of generate preview elements on views, but in order to do so it needs some libraries, such as FFMpeg, Plopper and miniMagick, when I opened #66 it failed on travis due to not being capable of generate a PDF preview, the tool required to do so is Plopper, so this adds the tool isolated as an experiment to check if it does not fail (only the addition of the tool), if this works, the commit will be cherry-picked into #66 