### PR TITLE
Fix dontpad link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ### Description
 
-Dontfile is an open source project intended to concatenate the proposed idea of [dontpad](dontpad.com) aggregating the same logic to files along with texts, thus creating a more complete tool.
+Dontfile is an open source project intended to concatenate the proposed idea of [dontpad](http://dontpad.com/) aggregating the same logic to files along with texts, thus creating a more complete tool.
 
 * Ruby version: 2.5.1
 * Rails version: 5.2.1


### PR DESCRIPTION
### What does this implement/fix? ###
<!-- What does this PR do? Beautify, add new feature, bug fix? What does it change? -->
Fix dontpad link in README.md.
It should be pointed to http://dontpad.com/ but https://github.com/MatheusRich/dontfile/blob/master/dontpad.com.

### Does this close any currently open issues? ###
<!-- If it solves an issue, mention it's number like "fixes #10" -->
No

### Explain your solution ###
<!-- What steps/decisions did you take to reach the current state of PR. -->

### Any other comments? ###
<!-- Anything else you feel we should know. -->
